### PR TITLE
Fix variable masks -> cellpose_masks

### DIFF
--- a/Day_4/Cellpose.ipynb
+++ b/Day_4/Cellpose.ipynb
@@ -350,7 +350,7 @@
    "outputs": [],
    "source": [
     "from cellpose import io, utils\n",
-    "outlines = utils.outlines_list(masks)\n",
+    "outlines = utils.outlines_list(cellpose_masks)\n",
     "io.outlines_to_text(str(image_id), outlines)"
    ]
   },


### PR DESCRIPTION
@jburel Opening this as a PR, because it is a change in code.

The cell is throwing an error, complaining that ``masks`` is not defined.

This PR is a fix suggestion.