### PR TITLE
Cellpose: more displays of the labels to make comparison clear

### DIFF
--- a/Day_4/Cellpose.ipynb
+++ b/Day_4/Cellpose.ipynb
@@ -306,7 +306,7 @@
    "source": [
     "## Load the ROIs from IDR\n",
     "\n",
-    "Load the original labels in order to compare them with the Cellpose ones Original labels have been saved as mask."
+    "Original labels have been saved as mask ROIs in IDR. Load the original labels in order to compare them with the Cellpose ones."
    ]
   },
   {
@@ -368,10 +368,22 @@
     "c = 1\n",
     "t = 0\n",
     "fig = plt.figure(figsize=(10, 10))\n",
-    "plt.subplot(121)\n",
-    "plt.imshow(data[t, c, z, :, :], cmap='jet')\n",
+    "# Show the original labels from IDR\n",
+    "sub1 = plt.subplot(121)\n",
+    "sub1.title.set_text('Original labels IDR')\n",
     "plt.imshow(labels[t, c, z, :, :], cmap='gray', alpha=0.5)\n",
-    "plt.subplot(122)\n",
+    "# Show the Cellpose labels\n",
+    "sub2 = plt.subplot(122)\n",
+    "sub2.title.set_text('Cellpose labels this notebook')\n",
+    "plt.imshow(cellpose_masks, cmap='jet', alpha=0.5)\n",
+    "fig2 = plt.figure(figsize=(8.5, 8.5))\n",
+    "# Show the original image\n",
+    "sub3 = plt.subplot(121)\n",
+    "sub3.title.set_text(\"Original unsegmented image\")\n",
+    "plt.imshow(data[t, c, z, :, :], cmap='jet')\n",
+    "# Show the Cellpose labels\n",
+    "sub4 = plt.subplot(122)\n",
+    "sub4.title.set_text('Cellpose labels this notebook')\n",
     "plt.imshow(cellpose_masks, cmap='jet', alpha=0.5)\n",
     "plt.tight_layout()\n",
     "fig.canvas.flush_events()"


### PR DESCRIPTION
@jburel 
Day_4, cellpose:
Just adding more image plots and headers to make clear what is on the compared panels, 

Before

![Screenshot 2023-05-18 at 13 08 18](https://github.com/ome/EMBL-EBI-imaging-course-05-2023/assets/2478303/8fc9636f-8222-4e83-8216-6e11c9e8ef6b)


After

![Screenshot 2023-05-18 at 13 07 19](https://github.com/ome/EMBL-EBI-imaging-course-05-2023/assets/2478303/7956b9de-04e9-46f1-bfa5-93fbbbd9b8b9)

