### PR TITLE
Use explicit path as new terminal window is used

### DIFF
--- a/Day_5/Conversion.ipynb
+++ b/Day_5/Conversion.ipynb
@@ -172,7 +172,8 @@
    "source": [
     "- Convert the ``B4_C3.tif`` image into ``OME-Zarr``.\n",
     "```\n",
-    "bioformats2raw --debug=OFF --progress /home/training/EMBL-EBI-imaging-course-05-2023/Day_4/includes/B4_C3.tif /tmp/conversion_out/B4_C3.ome.zarr\n",
+    "cd EMBL-EBI-imaging-course-05-2023\n",
+    "bioformats2raw --debug=OFF --progress Day_4/includes/B4_C3.tif /tmp/conversion_out/B4_C3.ome.zarr\n",
     "```"
    ]
   },

--- a/Day_5/Conversion.ipynb
+++ b/Day_5/Conversion.ipynb
@@ -172,7 +172,7 @@
    "source": [
     "- Convert the ``B4_C3.tif`` image into ``OME-Zarr``.\n",
     "```\n",
-    "bioformats2raw --debug=OFF --progress Day_4/includes/B4_C3.tif /tmp/conversion_out/B4_C3.ome.zarr\n",
+    "bioformats2raw --debug=OFF --progress /home/training/EMBL-EBI-imaging-course-05-2023/Day_4/includes/B4_C3.tif /tmp/conversion_out/B4_C3.ome.zarr\n",
     "```"
    ]
   },


### PR DESCRIPTION
Opening that as a PR because not sure if this is the best approach.

Problem:
1. In the EMBL-provided VM, build the ``conversion`` env and start Jupyter from that terminal window
2. Go through the conversion notebook in the browser. But the commands need to be pasted into a terminal window from there.
3. Open a new terminal window. This will bring you into the ``~`` (home) folder, not into the ``EMBL...`` checkout folder of this repo.
4. When you execute the ``bioformats2raw ...`` command as written in the new terminal window, it will fail because the path to the to-be-converted file is wrong.

cc @jburel 